### PR TITLE
Add SERVICE in wrangler.toml

### DIFF
--- a/src/context/logging.ts
+++ b/src/context/logging.ts
@@ -16,6 +16,7 @@ export interface Logger {
 interface SentryOptions {
 	context: Context;
 	request: Request;
+	service: string;
 	dsn: string;
 	accessClientId: string;
 	accessClientSecret: string;
@@ -23,7 +24,6 @@ interface SentryOptions {
 
 	sampleRate?: number;
 	coloName?: string;
-	service?: string;
 }
 
 export class FlexibleLogger implements Logger {
@@ -66,7 +66,7 @@ export class SentryLogger implements Logger {
 		this.environment = environment;
 		this.context = options.context;
 		this.request = options.request;
-		this.service = options.service || '';
+		this.service = options.service;
 
 		this.sentry = new Toucan({
 			dsn: options.dsn,

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,6 +17,7 @@ crons = ["0 0 * * *"]
 DIRECTORY_CACHE_MAX_AGE_SECONDS = "86400"
 ENVIRONMENT = "production"
 SENTRY_SAMPLE_RATE = "0" # Between 0-1 if you log errors on Sentry. 0 disables Sentry logging. Configuration is done through Workers Secrets
+SERVICE = "pp-issuer-production"
 
 [[env.production.r2_buckets]]
 bucket_name = 'pp-issuer-keys-production' # wrangler r2 bucket create pp-issuer-keys-production. Pricing and free tier described on https://developers.cloudflare.com/r2/pricing


### PR DESCRIPTION
The previous commit introduces `SERVICE`. This one enforces it's definition, and proposes an example in `wrangler.toml`